### PR TITLE
csmake-swak: GH-#10 Fixing the SHA-1 output to string

### DIFF
--- a/CsmakeModules/RpmPackage.py
+++ b/CsmakeModules/RpmPackage.py
@@ -1403,7 +1403,7 @@ class RpmPackage(Packager):
         item = RpmPackage.RpmRecordInt32(1007, self.totalUncompressedPayload)
         sigBlock.addRecord(item)
         #1010 == RPMSIGTAG_SHA1 - sha1 of the header content
-        item = RpmPackage.RpmRecordString(1010, self.headerSHA.digest())
+        item = RpmPackage.RpmRecordString(1010, self.headerSHA.hexdigest())
         sigBlock.addRecord(item)
         #RSA/DSA/PGP/GPG Signatures would go here...
         return sigBlock
@@ -1451,6 +1451,7 @@ class RpmPackage(Packager):
         self.headers.write(self.archiveHeaders, headerdigests)
 	self.totalPayloadSize = self.archiveHeaders.tell()
         self.archiveHeaders.close()
+        self.archive.flush()
         self.archive.seek(0)
         block = self.archive.read(10240)
         while len(block) > 0:

--- a/csmakefile
+++ b/csmakefile
@@ -35,7 +35,7 @@ rpm=zlib-devel
 
 [metadata@csmake-packaging]
 name=csmake-packaging
-version=1.1.2
+version=1.1.3
 description=Library of csmake modules to create packages
 about=The core csmake contains minimal support for packaging
  This library is intended to round out support for more robust


### PR DESCRIPTION
This resolves https://github.com/devops-csmake/csmake-swak/issues/10 from devops-csmake/csmake-packaging